### PR TITLE
Fix reference values when swapping range pointers.

### DIFF
--- a/rzslider.js
+++ b/rzslider.js
@@ -635,12 +635,14 @@ angular.module('rzModule', [])
       {
         if (this.tracking === this.refLow && newValue >= this.scope[this.refHigh])
         {
+          this.scope[this.tracking] = this.scope[this.refHigh];
           this.tracking = this.refHigh;
           this.minPtr.removeClass('active');
           this.maxPtr.addClass('active');
         }
         else if(newValue <= this.scope[this.refLow])
         {
+          this.scope[this.tracking] = this.scope[this.refLow];
           this.tracking = this.refLow;
           this.maxPtr.removeClass('active');
           this.minPtr.addClass('active');


### PR DESCRIPTION
When you drag one range pointer past the other, they 'swap' and you continue dragging the other one. However, if you did this rapidly the range would wander. This locks the values so that this wandering doesn't happen.
