### PR TITLE
Update rzslider.js

### DIFF
--- a/rzslider.js
+++ b/rzslider.js
@@ -784,13 +784,13 @@ function throttle(func, wait, options) {
 
       if(event.touches)
       {
-        $document.on('touchmove', angular.bind(this, this.onMove, pointer));
-        $document.on('touchend', angular.bind(this, this.onEnd));
+        $document.on('touchmove.rzslider', angular.bind(this, this.onMove, pointer));
+        $document.on('touchend.rzslider', angular.bind(this, this.onEnd));
       }
       else
       {
-        $document.on('mousemove', angular.bind(this, this.onMove, pointer));
-        $document.on('mouseup', angular.bind(this, this.onEnd));
+        $document.on('mousemove.rzslider', angular.bind(this, this.onMove, pointer));
+        $document.on('mouseup.rzslider', angular.bind(this, this.onEnd));
       }
     },
 
@@ -876,13 +876,13 @@ function throttle(func, wait, options) {
 
       if(event.touches)
       {
-        $document.unbind('touchmove');
-        $document.unbind('touchend');
+        $document.unbind('touchmove.rzslider');
+        $document.unbind('touchend.rzslider');
       }
       else
       {
-        $document.unbind('mousemove');
-        $document.unbind('mouseup');
+        $document.unbind('mousemove.rzslider');
+        $document.unbind('mouseup.rzslider');
       }
 
       this.tracking = '';


### PR DESCRIPTION
Bug when use with other drag&drop framework, specify an event handler with specific type allow to not destroy other general purpose "onmouse" event handler (jquery-ui)
