### PR TITLE
Update label width when tabbed.

### DIFF
--- a/rzslider.js
+++ b/rzslider.js
@@ -338,7 +338,7 @@ function throttle(func, wait, options) {
       var valStr = this.customTrFn && useCustomTr ? '' + this.customTrFn(value) : '' + value,
         getWidth = false;
 
-      if(label.rzsv === undefined || label.rzsv.length != valStr.length)
+      if(label.rzsv === undefined || label.rzsv.length != valStr.length || (label.rzsv.length > 0 && label.rzsw == 0))
       {
         getWidth = true;
         label.rzsv = valStr;


### PR DESCRIPTION
Fixed the label not being centered when loaded hidden until after
clicking the slider. (Issue visible in demo/tabs.html)
