### PR TITLE
ui.bootstrap upgrade

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -1,6 +1,6 @@
 var app = angular.module('rzSliderDemo', ['rzModule', 'ui.bootstrap']);
 
-app.controller('MainCtrl', function($scope, $rootScope, $timeout, $modal) {
+app.controller('MainCtrl', function($scope, $rootScope, $timeout, $uibModal) {
   //Minimal slider config
   $scope.minSlider = {
     value: 10
@@ -517,9 +517,9 @@ app.controller('MainCtrl', function($scope, $rootScope, $timeout, $modal) {
     }
   };
   $scope.openModal = function() {
-    var modalInstance = $modal.open({
+    var modalInstance = $uibModal.open({
       templateUrl: 'sliderModal.html',
-      controller: function($scope, $modalInstance, values) {
+      controller: function($scope, $uibModalInstance, values) {
         $scope.percentages = JSON.parse(JSON.stringify(values)); //Copy of the object in order to keep original values in $scope.percentages in parent controller.
 
 
@@ -539,10 +539,10 @@ app.controller('MainCtrl', function($scope, $rootScope, $timeout, $modal) {
           translate: formatToPercentage
         };
         $scope.ok = function() {
-          $modalInstance.close($scope.percentages);
+          $uibModalInstance.close($scope.percentages);
         };
         $scope.cancel = function() {
-          $modalInstance.dismiss();
+          $uibModalInstance.dismiss();
         };
       },
       resolve: {

--- a/demo/index.html
+++ b/demo/index.html
@@ -351,14 +351,14 @@
     <h2>Sliders inside tabs</h2>
     <p>Price 1: {{tabSliders.slider1.value}}</p>
     <p>Price 2: {{tabSliders.slider2.value}}</p>
-    <tabset>
-      <tab heading="Slider 1" select="refreshSlider()">
+    <uib-tabset>
+      <uib-tab heading="Slider 1" select="refreshSlider()">
         <rzslider rz-slider-model="tabSliders.slider1.value"></rzslider>
-      </tab>
-      <tab heading="Slider 2" select="refreshSlider()">
+      </uib-tab>
+      <uib-tab heading="Slider 2" select="refreshSlider()">
         <rzslider rz-slider-model="tabSliders.slider2.value"></rzslider>
-      </tab>
-    </tabset>
+      </uib-tab>
+    </uib-tabset>
   </article>
 
   <article>


### PR DESCRIPTION
Update to the demo html and js files to use latest ui.bootstrap component names, namely

`$modal` -> `$uibModal`

`<tab>` -> `<uib-tab>`
`<tabset>` -> `<uib-tabset>`