### PR TITLE
fix(ticks): Ensure model value is current when custom translate funct…

### DIFF
--- a/src/rzslider.js
+++ b/src/rzslider.js
@@ -2058,7 +2058,7 @@
         this.applyLowValue();
         if (this.range)
           this.applyHighValue();
-        this.applyModel();
+        this.applyModel(true);
         this.updateHandles('lowValue', this.valueToPosition(newMinValue));
         this.updateHandles('highValue', this.valueToPosition(newMaxValue));
       },
@@ -2070,7 +2070,6 @@
        */
       positionTrackingHandle: function(newValue) {
         var valueChanged = false;
-
         newValue = this.applyMinMaxLimit(newValue);
         if (this.range) {
           if (this.options.pushRange) {
@@ -2089,6 +2088,7 @@
             if (this.tracking === 'lowValue' && newValue > this.highValue) {
               this.lowValue = this.highValue;
               this.applyLowValue();
+              this.applyModel();
               this.updateHandles(this.tracking, this.maxH.rzsp);
               this.updateAriaAttributes();
               this.tracking = 'highValue';
@@ -2101,6 +2101,7 @@
             else if (this.tracking === 'highValue' && newValue < this.lowValue) {
               this.highValue = this.lowValue;
               this.applyHighValue();
+              this.applyModel();
               this.updateHandles(this.tracking, this.minH.rzsp);
               this.updateAriaAttributes();
               this.tracking = 'lowValue';
@@ -2119,13 +2120,14 @@
             this.applyLowValue();
           else
             this.applyHighValue();
+          this.applyModel();
           this.updateHandles(this.tracking, this.valueToPosition(newValue));
           this.updateAriaAttributes();
           valueChanged = true;
         }
 
         if (valueChanged)
-          this.applyModel();
+          this.applyModel(true);
       },
 
       applyMinMaxLimit: function(newValue) {
@@ -2199,10 +2201,10 @@
        * Apply the model values using scope.$apply.
        * We wrap it with the internalChange flag to avoid the watchers to be called
        */
-      applyModel: function() {
+      applyModel: function(callOnChange) {
         this.internalChange = true;
         this.scope.$apply();
-        this.callOnChange();
+        callOnChange && this.callOnChange();
         this.internalChange = false;
       },
 

--- a/tests/specs/helper-functions-test.js
+++ b/tests/specs/helper-functions-test.js
@@ -705,7 +705,15 @@
         expect(helper.slider.positionToValue(1000)).to.equal(-100);
         expect(helper.slider.positionToValue(500)).to.equal(-50);
       });
+      it('should conditionally call callOnChange in applyModel', function() {
+        sinon.spy(helper.slider, 'callOnChange');
+
+        helper.slider.applyModel(false);
+        helper.slider.callOnChange.called.should.be.false;
+
+        helper.slider.applyModel(true);
+        expect(helper.slider.callOnChange.callCount).to.equal(1);
+      });
     });
   });
 }());
-

--- a/tests/specs/mouse-controls/draggable-range-slider-horizontal-test.js
+++ b/tests/specs/mouse-controls/draggable-range-slider-horizontal-test.js
@@ -44,8 +44,8 @@
       var expectedValue = 50;
       helper.moveMouseToValue(expectedValue);
       expect(helper.scope.slider.min).to.equal(expectedValue);
-      helper.slider.positionTrackingHandle.called.should.be.true;
-      helper.slider.callOnChange.called.should.be.true;
+      expect(helper.slider.positionTrackingHandle.callCount).to.equal(1);
+      expect(helper.slider.callOnChange.callCount).to.equal(1);
     });
 
     it('should handle click and drag on maxH correctly when mouse is on the middle', function() {
@@ -55,8 +55,8 @@
       var expectedValue = 50;
       helper.moveMouseToValue(expectedValue);
       expect(helper.scope.slider.max).to.equal(expectedValue);
-      helper.slider.positionTrackingHandle.called.should.be.true;
-      helper.slider.callOnChange.called.should.be.true;
+      expect(helper.slider.positionTrackingHandle.callCount).to.equal(1);
+      expect(helper.slider.callOnChange.callCount).to.equal(1);
     });
 
     it('should handle click and drag on minH and switch min/max if needed', function() {
@@ -91,9 +91,9 @@
       expect(helper.scope.slider.min).to.equal(expectedValue);
       expect(helper.slider.tracking).to.equal('lowValue');
       helper.slider.focusElement.calledWith(helper.slider.minH).should.be.true;
-      helper.slider.positionTrackingHandle.called.should.be.true;
-      helper.slider.callOnStart.called.should.be.true;
-      helper.slider.callOnChange.called.should.be.true;
+      expect(helper.slider.positionTrackingHandle.callCount).to.equal(1);
+      expect(helper.slider.callOnStart.callCount).to.equal(1);
+      expect(helper.slider.callOnChange.callCount).to.equal(1);
     });
 
     it('should handle click on fullbar and move maxH when click pos is nearer to maxH', function() {
@@ -110,9 +110,9 @@
       expect(helper.scope.slider.max).to.equal(expectedValue);
       expect(helper.slider.tracking).to.equal('highValue');
       helper.slider.focusElement.calledWith(helper.slider.maxH).should.be.true;
-      helper.slider.positionTrackingHandle.called.should.be.true;
-      helper.slider.callOnStart.called.should.be.true;
-      helper.slider.callOnChange.called.should.be.true;
+      expect(helper.slider.positionTrackingHandle.callCount).to.equal(1);
+      expect(helper.slider.callOnStart.callCount).to.equal(1);
+      expect(helper.slider.callOnChange.callCount).to.equal(1);
     });
 
     it('should handle click on selbar and move whole range when moved within slider range', function() {
@@ -131,9 +131,9 @@
       expect(helper.scope.slider.max).to.equal(70);
       expect(helper.slider.tracking).to.equal('lowValue');
       helper.slider.focusElement.calledWith(helper.slider.minH).should.be.true;
-      helper.slider.positionTrackingBar.called.should.be.true;
-      helper.slider.callOnStart.called.should.be.true;
-      helper.slider.callOnChange.called.should.be.true;
+      expect(helper.slider.positionTrackingBar.callCount).to.equal(2);
+      expect(helper.slider.callOnStart.callCount).to.equal(1);
+      expect(helper.slider.callOnChange.callCount).to.equal(2);
     });
 
     it('should handle click on selbar and move move range when near 0 and moved left', function() {
@@ -265,8 +265,8 @@
           position = helper.getMousePosition(expectedValue);
       helper.fireMousemove(position);
       expect(helper.scope.slider.min).to.equal(expectedValue);
-      helper.slider.positionTrackingHandle.called.should.be.true;
-      helper.slider.callOnChange.called.should.be.true;
+      expect(helper.slider.positionTrackingHandle.callCount).to.equal(1);
+      expect(helper.slider.callOnChange.callCount).to.equal(1);
     });
 
     it('should handle click and drag on maxH correctly when mouse is on the middle', function() {
@@ -277,8 +277,8 @@
           position = helper.getMousePosition(expectedValue);
       helper.fireMousemove(position);
       expect(helper.scope.slider.max).to.equal(expectedValue);
-      helper.slider.positionTrackingHandle.called.should.be.true;
-      helper.slider.callOnChange.called.should.be.true;
+      expect(helper.slider.positionTrackingHandle.callCount).to.equal(1);
+      expect(helper.slider.callOnChange.callCount).to.equal(1);
     });
 
     it('should handle click and drag on minH and switch min/max if needed', function() {
@@ -315,9 +315,9 @@
       expect(helper.scope.slider.min).to.equal(expectedValue);
       expect(helper.slider.tracking).to.equal('lowValue');
       helper.slider.focusElement.calledWith(helper.slider.minH).should.be.true;
-      helper.slider.positionTrackingHandle.called.should.be.true;
-      helper.slider.callOnStart.called.should.be.true;
-      helper.slider.callOnChange.called.should.be.true;
+      expect(helper.slider.positionTrackingHandle.callCount).to.equal(1);
+      expect(helper.slider.callOnStart.callCount).to.equal(1);
+      expect(helper.slider.callOnChange.callCount).to.equal(1);
     });
 
     it('should handle click on fullbar and move maxH when click pos is nearer to maxH', function() {
@@ -334,9 +334,9 @@
       expect(helper.scope.slider.max).to.equal(expectedValue);
       expect(helper.slider.tracking).to.equal('highValue');
       helper.slider.focusElement.calledWith(helper.slider.maxH).should.be.true;
-      helper.slider.positionTrackingHandle.called.should.be.true;
-      helper.slider.callOnStart.called.should.be.true;
-      helper.slider.callOnChange.called.should.be.true;
+      expect(helper.slider.positionTrackingHandle.callCount).to.equal(1);
+      expect(helper.slider.callOnStart.callCount).to.equal(1);
+      expect(helper.slider.callOnChange.callCount).to.equal(1);
     });
 
     it('should handle click on selbar and move whole range when moved within slider range', function() {
@@ -355,9 +355,9 @@
       expect(helper.scope.slider.max).to.equal(50);
       expect(helper.slider.tracking).to.equal('highValue');
       helper.slider.focusElement.calledWith(helper.slider.maxH).should.be.true;
-      helper.slider.positionTrackingBar.called.should.be.true;
-      helper.slider.callOnStart.called.should.be.true;
-      helper.slider.callOnChange.called.should.be.true;
+      expect(helper.slider.positionTrackingBar.callCount).to.equal(2);
+      expect(helper.slider.callOnStart.callCount).to.equal(1);
+      expect(helper.slider.callOnChange.callCount).to.equal(2);
     });
 
     it('should handle click on selbar and move move range when near 0 and moved right', function() {
@@ -422,4 +422,3 @@
     });
   });
 }());
-

--- a/tests/specs/mouse-controls/draggableOnly-range-slider-horizontal-test.js
+++ b/tests/specs/mouse-controls/draggableOnly-range-slider-horizontal-test.js
@@ -48,8 +48,8 @@
 
       expect(helper.scope.slider.min).to.equal(50);
       expect(helper.scope.slider.max).to.equal(70);
-      helper.slider.positionTrackingBar.called.should.be.true;
-      helper.slider.callOnChange.called.should.be.true;
+      expect(helper.slider.positionTrackingBar.callCount).to.equal(1);
+      expect(helper.slider.callOnChange.callCount).to.equal(1);
     });
 
     it('should handle click and drag on maxH correctly', function() {
@@ -61,8 +61,8 @@
       helper.fireMousemove(position);
       expect(helper.scope.slider.min).to.equal(50);
       expect(helper.scope.slider.max).to.equal(70);
-      helper.slider.positionTrackingBar.called.should.be.true;
-      helper.slider.callOnChange.called.should.be.true;
+      expect(helper.slider.positionTrackingBar.callCount).to.equal(1);
+      expect(helper.slider.callOnChange.callCount).to.equal(1);
     });
 
     it('should not handle click on fullbar', function() {
@@ -95,9 +95,9 @@
       expect(helper.scope.slider.max).to.equal(70);
       expect(helper.slider.tracking).to.equal('lowValue');
       helper.slider.focusElement.calledWith(helper.slider.minH).should.be.true;
-      helper.slider.positionTrackingBar.called.should.be.true;
-      helper.slider.callOnStart.called.should.be.true;
-      helper.slider.callOnChange.called.should.be.true;
+      expect(helper.slider.positionTrackingBar.callCount).to.equal(2);
+      expect(helper.slider.callOnStart.callCount).to.equal(1);
+      expect(helper.slider.callOnChange.callCount).to.equal(2);
     });
 
     it('should handle click on selbar and move range when near 0 and moved left', function() {
@@ -212,8 +212,8 @@
 
       expect(helper.scope.slider.min).to.equal(50);
       expect(helper.scope.slider.max).to.equal(70);
-      helper.slider.positionTrackingBar.called.should.be.true;
-      helper.slider.callOnChange.called.should.be.true;
+      expect(helper.slider.positionTrackingBar.callCount).to.equal(1);
+      expect(helper.slider.callOnChange.callCount).to.equal(1);
     });
 
     it('should handle click and drag on maxH correctly', function() {
@@ -225,8 +225,8 @@
       helper.fireMousemove(position);
       expect(helper.scope.slider.min).to.equal(50);
       expect(helper.scope.slider.max).to.equal(70);
-      helper.slider.positionTrackingBar.called.should.be.true;
-      helper.slider.callOnChange.called.should.be.true;
+      expect(helper.slider.positionTrackingBar.callCount).to.equal(1);
+      expect(helper.slider.callOnChange.callCount).to.equal(1);
     });
 
     it('should not handle click on fullbar', function() {
@@ -259,9 +259,9 @@
       expect(helper.scope.slider.max).to.equal(70);
       expect(helper.slider.tracking).to.equal('lowValue');
       helper.slider.focusElement.calledWith(helper.slider.minH).should.be.true;
-      helper.slider.positionTrackingBar.called.should.be.true;
-      helper.slider.callOnStart.called.should.be.true;
-      helper.slider.callOnChange.called.should.be.true;
+      expect(helper.slider.positionTrackingBar.callCount).to.equal(2);
+      expect(helper.slider.callOnStart.callCount).to.equal(1);
+      expect(helper.slider.callOnChange.callCount).to.equal(2);
     });
 
     it('should handle click on selbar and move range when near 0 and moved left', function() {
@@ -328,4 +328,3 @@
     });
   });
 }());
-

--- a/tests/specs/mouse-controls/onlyBindHandles-single-slider-horizontal-test.js
+++ b/tests/specs/mouse-controls/onlyBindHandles-single-slider-horizontal-test.js
@@ -44,8 +44,8 @@
       var expectedValue = 50;
       helper.moveMouseToValue(expectedValue);
       expect(helper.scope.slider.value).to.equal(expectedValue);
-      helper.slider.positionTrackingHandle.called.should.be.true;
-      helper.slider.callOnChange.called.should.be.true;
+      expect(helper.slider.positionTrackingHandle.callCount).to.equal(1);
+      expect(helper.slider.callOnChange.callCount).to.equal(1);
     });
 
     it('should do nothing when a click happen on another element than the handle', function() {
@@ -106,8 +106,8 @@
       var expectedValue = 50;
       helper.moveMouseToValue(expectedValue);
       expect(helper.scope.slider.value).to.equal(expectedValue);
-      helper.slider.positionTrackingHandle.called.should.be.true;
-      helper.slider.callOnChange.called.should.be.true;
+      expect(helper.slider.positionTrackingHandle.callCount).to.equal(1);
+      expect(helper.slider.callOnChange.callCount).to.equal(1);
     });
 
     it('should do nothing when a click happen on another element than the handle', function() {
@@ -124,4 +124,3 @@
     });
   });
 }());
-

--- a/tests/specs/mouse-controls/range-slider-horizontal-test.js
+++ b/tests/specs/mouse-controls/range-slider-horizontal-test.js
@@ -113,8 +113,8 @@
       var expectedValue = 50;
       helper.moveMouseToValue(expectedValue);
       expect(helper.scope.slider.min).to.equal(expectedValue);
-      helper.slider.positionTrackingHandle.called.should.be.true;
-      helper.slider.callOnChange.called.should.be.true;
+      expect(helper.slider.positionTrackingHandle.callCount).to.equal(1);
+      expect(helper.slider.callOnChange.callCount).to.equal(1);
     });
 
     it('should handle click and drag on maxH correctly when mouse is on the middle', function() {
@@ -124,8 +124,8 @@
       var expectedValue = 50;
       helper.moveMouseToValue(expectedValue);
       expect(helper.scope.slider.max).to.equal(expectedValue);
-      helper.slider.positionTrackingHandle.called.should.be.true;
-      helper.slider.callOnChange.called.should.be.true;
+      expect(helper.slider.positionTrackingHandle.callCount).to.equal(1);
+      expect(helper.slider.callOnChange.callCount).to.equal(1);
     });
 
     it('should handle click and drag on minH and switch min/max if needed', function() {
@@ -204,9 +204,9 @@
       expect(helper.scope.slider.min).to.equal(expectedValue);
       expect(helper.slider.tracking).to.equal('lowValue');
       helper.slider.focusElement.calledWith(helper.slider.minH).should.be.true;
-      helper.slider.positionTrackingHandle.called.should.be.true;
-      helper.slider.callOnStart.called.should.be.true;
-      helper.slider.callOnChange.called.should.be.true;
+      expect(helper.slider.positionTrackingHandle.callCount).to.equal(1);
+      expect(helper.slider.callOnStart.callCount).to.equal(1);
+      expect(helper.slider.callOnChange.callCount).to.equal(1);
     });
 
     it('should handle click on fullbar and move maxH when click pos is nearer to maxH', function() {
@@ -223,9 +223,9 @@
       expect(helper.scope.slider.max).to.equal(expectedValue);
       expect(helper.slider.tracking).to.equal('highValue');
       helper.slider.focusElement.calledWith(helper.slider.maxH).should.be.true;
-      helper.slider.positionTrackingHandle.called.should.be.true;
-      helper.slider.callOnStart.called.should.be.true;
-      helper.slider.callOnChange.called.should.be.true;
+      expect(helper.slider.positionTrackingHandle.callCount).to.equal(1);
+      expect(helper.slider.callOnStart.callCount).to.equal(1);
+      expect(helper.slider.callOnChange.callCount).to.equal(1);
     });
 
     it('should handle click on selbar and move minH when click pos is nearer to minH', function() {
@@ -242,9 +242,9 @@
       expect(helper.scope.slider.min).to.equal(expectedValue);
       expect(helper.slider.tracking).to.equal('lowValue');
       helper.slider.focusElement.calledWith(helper.slider.minH).should.be.true;
-      helper.slider.positionTrackingHandle.called.should.be.true;
-      helper.slider.callOnStart.called.should.be.true;
-      helper.slider.callOnChange.called.should.be.true;
+      expect(helper.slider.positionTrackingHandle.callCount).to.equal(1);
+      expect(helper.slider.callOnStart.callCount).to.equal(1);
+      expect(helper.slider.callOnChange.callCount).to.equal(1);
     });
 
     it('should handle click on selbar and move maxH when click pos is nearer to maxH', function() {
@@ -261,9 +261,9 @@
       expect(helper.scope.slider.max).to.equal(expectedValue);
       expect(helper.slider.tracking).to.equal('highValue');
       helper.slider.focusElement.calledWith(helper.slider.maxH).should.be.true;
-      helper.slider.positionTrackingHandle.called.should.be.true;
-      helper.slider.callOnStart.called.should.be.true;
-      helper.slider.callOnChange.called.should.be.true;
+      expect(helper.slider.positionTrackingHandle.callCount).to.equal(1);
+      expect(helper.slider.callOnStart.callCount).to.equal(1);
+      expect(helper.slider.callOnChange.callCount).to.equal(1);
     });
   });
 
@@ -380,8 +380,8 @@
       var expectedValue = 50;
       helper.moveMouseToValue(expectedValue);
       expect(helper.scope.slider.min).to.equal(expectedValue);
-      helper.slider.positionTrackingHandle.called.should.be.true;
-      helper.slider.callOnChange.called.should.be.true;
+      expect(helper.slider.positionTrackingHandle.callCount).to.equal(1);
+      expect(helper.slider.callOnChange.callCount).to.equal(1);
     });
 
     it('should handle click and drag on maxH correctly when mouse is on the middle', function() {
@@ -391,8 +391,8 @@
       var expectedValue = 50;
       helper.moveMouseToValue(expectedValue);
       expect(helper.scope.slider.max).to.equal(expectedValue);
-      helper.slider.positionTrackingHandle.called.should.be.true;
-      helper.slider.callOnChange.called.should.be.true;
+      expect(helper.slider.positionTrackingHandle.callCount).to.equal(1);
+      expect(helper.slider.callOnChange.callCount).to.equal(1);
     });
 
     it('should handle click and drag on minH and switch min/max if needed', function() {
@@ -471,9 +471,9 @@
       expect(helper.scope.slider.min).to.equal(expectedValue);
       expect(helper.slider.tracking).to.equal('lowValue');
       helper.slider.focusElement.calledWith(helper.slider.minH).should.be.true;
-      helper.slider.positionTrackingHandle.called.should.be.true;
-      helper.slider.callOnStart.called.should.be.true;
-      helper.slider.callOnChange.called.should.be.true;
+      expect(helper.slider.positionTrackingHandle.callCount).to.equal(1);
+      expect(helper.slider.callOnStart.callCount).to.equal(1);
+      expect(helper.slider.callOnChange.callCount).to.equal(1);
     });
 
     it('should handle click on fullbar and move maxH when click pos is nearer to maxH', function() {
@@ -490,9 +490,9 @@
       expect(helper.scope.slider.max).to.equal(expectedValue);
       expect(helper.slider.tracking).to.equal('highValue');
       helper.slider.focusElement.calledWith(helper.slider.maxH).should.be.true;
-      helper.slider.positionTrackingHandle.called.should.be.true;
-      helper.slider.callOnStart.called.should.be.true;
-      helper.slider.callOnChange.called.should.be.true;
+      expect(helper.slider.positionTrackingHandle.callCount).to.equal(1);
+      expect(helper.slider.callOnStart.callCount).to.equal(1);
+      expect(helper.slider.callOnChange.callCount).to.equal(1);
     });
 
     it('should handle click on selbar and move minH when click pos is nearer to minH', function() {
@@ -509,9 +509,9 @@
       expect(helper.scope.slider.min).to.equal(expectedValue);
       expect(helper.slider.tracking).to.equal('lowValue');
       helper.slider.focusElement.calledWith(helper.slider.minH).should.be.true;
-      helper.slider.positionTrackingHandle.called.should.be.true;
-      helper.slider.callOnStart.called.should.be.true;
-      helper.slider.callOnChange.called.should.be.true;
+      expect(helper.slider.positionTrackingHandle.callCount).to.equal(1);
+      expect(helper.slider.callOnStart.callCount).to.equal(1);
+      expect(helper.slider.callOnChange.callCount).to.equal(1);
     });
 
     it('should handle click on selbar and move maxH when click pos is nearer to maxH', function() {
@@ -528,10 +528,9 @@
       expect(helper.scope.slider.max).to.equal(expectedValue);
       expect(helper.slider.tracking).to.equal('highValue');
       helper.slider.focusElement.calledWith(helper.slider.maxH).should.be.true;
-      helper.slider.positionTrackingHandle.called.should.be.true;
-      helper.slider.callOnStart.called.should.be.true;
-      helper.slider.callOnChange.called.should.be.true;
+      expect(helper.slider.positionTrackingHandle.callCount).to.equal(1);
+      expect(helper.slider.callOnStart.callCount).to.equal(1);
+      expect(helper.slider.callOnChange.callCount).to.equal(1);
     });
   });
 }());
-

--- a/tests/specs/mouse-controls/range-slider-vertical-test.js
+++ b/tests/specs/mouse-controls/range-slider-vertical-test.js
@@ -115,8 +115,8 @@
         position = helper.slider.sliderElem.rzsp - helper.slider.valueToPosition(expectedValue) - helper.slider.handleHalfDim;
       helper.fireMousemove(position, true);
       expect(helper.scope.slider.min).to.equal(expectedValue);
-      helper.slider.positionTrackingHandle.called.should.be.true;
-      helper.slider.callOnChange.called.should.be.true;
+      expect(helper.slider.positionTrackingHandle.callCount).to.equal(1);
+      expect(helper.slider.callOnChange.callCount).to.equal(1);
     });
 
     it('should handle click and drag on maxH correctly when mouse is on the middle', function() {
@@ -127,8 +127,8 @@
         position = helper.slider.sliderElem.rzsp - helper.slider.valueToPosition(expectedValue) - helper.slider.handleHalfDim;
       helper.fireMousemove(position, true);
       expect(helper.scope.slider.max).to.equal(expectedValue);
-      helper.slider.positionTrackingHandle.called.should.be.true;
-      helper.slider.callOnChange.called.should.be.true;
+      expect(helper.slider.positionTrackingHandle.callCount).to.equal(1);
+      expect(helper.slider.callOnChange.callCount).to.equal(1);
     });
 
     it('should handle click and drag on minH and switch min/max if needed', function() {
@@ -173,9 +173,9 @@
       expect(helper.scope.slider.min).to.equal(expectedValue);
       expect(helper.slider.tracking).to.equal('lowValue');
       helper.slider.focusElement.calledWith(helper.slider.minH).should.be.true;
-      helper.slider.positionTrackingHandle.called.should.be.true;
-      helper.slider.callOnStart.called.should.be.true;
-      helper.slider.callOnChange.called.should.be.true;
+      expect(helper.slider.positionTrackingHandle.callCount).to.equal(1);
+      expect(helper.slider.callOnStart.callCount).to.equal(1);
+      expect(helper.slider.callOnChange.callCount).to.equal(1);
     });
 
     it('should handle click on fullbar and move maxH when click pos is nearer to maxH', function() {
@@ -192,9 +192,9 @@
       expect(helper.scope.slider.max).to.equal(expectedValue);
       expect(helper.slider.tracking).to.equal('highValue');
       helper.slider.focusElement.calledWith(helper.slider.maxH).should.be.true;
-      helper.slider.positionTrackingHandle.called.should.be.true;
-      helper.slider.callOnStart.called.should.be.true;
-      helper.slider.callOnChange.called.should.be.true;
+      expect(helper.slider.positionTrackingHandle.callCount).to.equal(1);
+      expect(helper.slider.callOnStart.callCount).to.equal(1);
+      expect(helper.slider.callOnChange.callCount).to.equal(1);
     });
 
     it('should handle click on selbar and move minH when click pos is nearer to minH', function() {
@@ -211,9 +211,9 @@
       expect(helper.scope.slider.min).to.equal(expectedValue);
       expect(helper.slider.tracking).to.equal('lowValue');
       helper.slider.focusElement.calledWith(helper.slider.minH).should.be.true;
-      helper.slider.positionTrackingHandle.called.should.be.true;
-      helper.slider.callOnStart.called.should.be.true;
-      helper.slider.callOnChange.called.should.be.true;
+      expect(helper.slider.positionTrackingHandle.callCount).to.equal(1);
+      expect(helper.slider.callOnStart.callCount).to.equal(1);
+      expect(helper.slider.callOnChange.callCount).to.equal(1);
     });
 
     it('should handle click on selbar and move maxH when click pos is nearer to maxH', function() {
@@ -230,9 +230,9 @@
       expect(helper.scope.slider.max).to.equal(expectedValue);
       expect(helper.slider.tracking).to.equal('highValue');
       helper.slider.focusElement.calledWith(helper.slider.maxH).should.be.true;
-      helper.slider.positionTrackingHandle.called.should.be.true;
-      helper.slider.callOnStart.called.should.be.true;
-      helper.slider.callOnChange.called.should.be.true;
+      expect(helper.slider.positionTrackingHandle.callCount).to.equal(1);
+      expect(helper.slider.callOnStart.callCount).to.equal(1);
+      expect(helper.slider.callOnChange.callCount).to.equal(1);
     });
   });
 
@@ -351,8 +351,8 @@
         position = helper.slider.sliderElem.rzsp - helper.slider.valueToPosition(expectedValue) - helper.slider.handleHalfDim;
       helper.fireMousemove(position, true);
       expect(helper.scope.slider.min).to.equal(expectedValue);
-      helper.slider.positionTrackingHandle.called.should.be.true;
-      helper.slider.callOnChange.called.should.be.true;
+      expect(helper.slider.positionTrackingHandle.callCount).to.equal(1);
+      expect(helper.slider.callOnChange.callCount).to.equal(1);
     });
 
     it('should handle click and drag on maxH correctly when mouse is on the middle', function() {
@@ -363,8 +363,8 @@
         position = helper.slider.sliderElem.rzsp - helper.slider.valueToPosition(expectedValue) - helper.slider.handleHalfDim;
       helper.fireMousemove(position, true);
       expect(helper.scope.slider.max).to.equal(expectedValue);
-      helper.slider.positionTrackingHandle.called.should.be.true;
-      helper.slider.callOnChange.called.should.be.true;
+      expect(helper.slider.positionTrackingHandle.callCount).to.equal(1);
+      expect(helper.slider.callOnChange.callCount).to.equal(1);
     });
 
     it('should handle click and drag on minH and switch min/max if needed', function() {
@@ -409,9 +409,9 @@
       expect(helper.scope.slider.min).to.equal(expectedValue);
       expect(helper.slider.tracking).to.equal('lowValue');
       helper.slider.focusElement.calledWith(helper.slider.minH).should.be.true;
-      helper.slider.positionTrackingHandle.called.should.be.true;
-      helper.slider.callOnStart.called.should.be.true;
-      helper.slider.callOnChange.called.should.be.true;
+      expect(helper.slider.positionTrackingHandle.callCount).to.equal(1);
+      expect(helper.slider.callOnStart.callCount).to.equal(1);
+      expect(helper.slider.callOnChange.callCount).to.equal(1);
     });
 
     it('should handle click on fullbar and move maxH when click pos is nearer to maxH', function() {
@@ -428,9 +428,9 @@
       expect(helper.scope.slider.max).to.equal(expectedValue);
       expect(helper.slider.tracking).to.equal('highValue');
       helper.slider.focusElement.calledWith(helper.slider.maxH).should.be.true;
-      helper.slider.positionTrackingHandle.called.should.be.true;
-      helper.slider.callOnStart.called.should.be.true;
-      helper.slider.callOnChange.called.should.be.true;
+      expect(helper.slider.positionTrackingHandle.callCount).to.equal(1);
+      expect(helper.slider.callOnStart.callCount).to.equal(1);
+      expect(helper.slider.callOnChange.callCount).to.equal(1);
     });
 
     it('should handle click on selbar and move minH when click pos is nearer to minH', function() {
@@ -447,9 +447,9 @@
       expect(helper.scope.slider.min).to.equal(expectedValue);
       expect(helper.slider.tracking).to.equal('lowValue');
       helper.slider.focusElement.calledWith(helper.slider.minH).should.be.true;
-      helper.slider.positionTrackingHandle.called.should.be.true;
-      helper.slider.callOnStart.called.should.be.true;
-      helper.slider.callOnChange.called.should.be.true;
+      expect(helper.slider.positionTrackingHandle.callCount).to.equal(1);
+      expect(helper.slider.callOnStart.callCount).to.equal(1);
+      expect(helper.slider.callOnChange.callCount).to.equal(1);
     });
 
     it('should handle click on selbar and move maxH when click pos is nearer to maxH', function() {
@@ -466,10 +466,9 @@
       expect(helper.scope.slider.max).to.equal(expectedValue);
       expect(helper.slider.tracking).to.equal('highValue');
       helper.slider.focusElement.calledWith(helper.slider.maxH).should.be.true;
-      helper.slider.positionTrackingHandle.called.should.be.true;
-      helper.slider.callOnStart.called.should.be.true;
-      helper.slider.callOnChange.called.should.be.true;
+      expect(helper.slider.positionTrackingHandle.callCount).to.equal(1);
+      expect(helper.slider.callOnStart.callCount).to.equal(1);
+      expect(helper.slider.callOnChange.callCount).to.equal(1);
     });
   });
 }());
-

--- a/tests/specs/mouse-controls/single-slider-horizontal-test.js
+++ b/tests/specs/mouse-controls/single-slider-horizontal-test.js
@@ -78,8 +78,8 @@
         position = helper.getMousePosition(expectedValue);
       helper.fireMousemove(position);
       expect(helper.scope.slider.value).to.equal(expectedValue);
-      helper.slider.positionTrackingHandle.called.should.be.true;
-      helper.slider.callOnChange.called.should.be.true;
+      expect(helper.slider.positionTrackingHandle.callCount).to.equal(1);
+      expect(helper.slider.callOnChange.callCount).to.equal(1);
     });
 
     it('should handle click and drag on minH correctly when mouse is before the slider and previous value was different than 0', function () {
@@ -142,9 +142,9 @@
 
       expect(helper.scope.slider.value).to.equal(expectedValue);
       expect(helper.slider.tracking).to.equal('lowValue');
-      helper.slider.positionTrackingHandle.called.should.be.true;
-      helper.slider.callOnStart.called.should.be.true;
-      helper.slider.callOnChange.called.should.be.true;
+      expect(helper.slider.positionTrackingHandle.callCount).to.equal(1);
+      expect(helper.slider.callOnStart.callCount).to.equal(1);
+      expect(helper.slider.callOnChange.callCount).to.equal(1);
     });
 
     it('should handle click on selbar and move minH', function () {
@@ -159,9 +159,9 @@
 
       expect(helper.scope.slider.value).to.equal(expectedValue);
       expect(helper.slider.tracking).to.equal('lowValue');
-      helper.slider.positionTrackingHandle.called.should.be.true;
-      helper.slider.callOnStart.called.should.be.true;
-      helper.slider.callOnChange.called.should.be.true;
+      expect(helper.slider.positionTrackingHandle.callCount).to.equal(1);
+      expect(helper.slider.callOnStart.callCount).to.equal(1);
+      expect(helper.slider.callOnChange.callCount).to.equal(1);
     });
 
     it('should handle click on ticks and move minH', function () {
@@ -179,9 +179,9 @@
 
       expect(helper.scope.slider.value).to.equal(expectedValue);
       expect(helper.slider.tracking).to.equal('lowValue');
-      helper.slider.positionTrackingHandle.called.should.be.true;
-      helper.slider.callOnStart.called.should.be.true;
-      helper.slider.callOnChange.called.should.be.true;
+      expect(helper.slider.positionTrackingHandle.callCount).to.equal(1);
+      expect(helper.slider.callOnStart.callCount).to.equal(1);
+      expect(helper.slider.callOnChange.callCount).to.equal(1);
     });
 
     it('should handle click on ticks when showTicks is an integer and move minH', function () {
@@ -199,9 +199,9 @@
 
       expect(helper.scope.slider.value).to.equal(expectedValue);
       expect(helper.slider.tracking).to.equal('lowValue');
-      helper.slider.positionTrackingHandle.called.should.be.true;
-      helper.slider.callOnStart.called.should.be.true;
-      helper.slider.callOnChange.called.should.be.true;
+      expect(helper.slider.positionTrackingHandle.callCount).to.equal(1);
+      expect(helper.slider.callOnStart.callCount).to.equal(1);
+      expect(helper.slider.callOnChange.callCount).to.equal(1);
     });
   });
 
@@ -283,8 +283,8 @@
           position = helper.getMousePosition(expectedValue);
         helper.fireMousemove(position);
         expect(helper.scope.slider.value).to.equal(expectedValue);
-        helper.slider.positionTrackingHandle.called.should.be.true;
-        helper.slider.callOnChange.called.should.be.true;
+        expect(helper.slider.positionTrackingHandle.callCount).to.equal(1);
+        expect(helper.slider.callOnChange.callCount).to.equal(1);
       });
 
       it('should handle click and drag on minH correctly when mouse is before the slider and previous value was different than 0', function() {
@@ -346,9 +346,9 @@
 
         expect(helper.scope.slider.value).to.equal(expectedValue);
         expect(helper.slider.tracking).to.equal('lowValue');
-        helper.slider.positionTrackingHandle.called.should.be.true;
-        helper.slider.callOnStart.called.should.be.true;
-        helper.slider.callOnChange.called.should.be.true;
+        expect(helper.slider.positionTrackingHandle.callCount).to.equal(1);
+        expect(helper.slider.callOnStart.callCount).to.equal(1);
+        expect(helper.slider.callOnChange.callCount).to.equal(1);
       });
 
       it('should handle click on selbar and move minH', function() {
@@ -363,9 +363,9 @@
 
         expect(helper.scope.slider.value).to.equal(expectedValue);
         expect(helper.slider.tracking).to.equal('lowValue');
-        helper.slider.positionTrackingHandle.called.should.be.true;
-        helper.slider.callOnStart.called.should.be.true;
-        helper.slider.callOnChange.called.should.be.true;
+        expect(helper.slider.positionTrackingHandle.callCount).to.equal(1);
+        expect(helper.slider.callOnStart.callCount).to.equal(1);
+        expect(helper.slider.callOnChange.callCount).to.equal(1);
       });
 
       it('should handle click on ticks and move minH', function() {
@@ -383,9 +383,9 @@
 
         expect(helper.scope.slider.value).to.equal(expectedValue);
         expect(helper.slider.tracking).to.equal('lowValue');
-        helper.slider.positionTrackingHandle.called.should.be.true;
-        helper.slider.callOnStart.called.should.be.true;
-        helper.slider.callOnChange.called.should.be.true;
+        expect(helper.slider.positionTrackingHandle.callCount).to.equal(1);
+        expect(helper.slider.callOnStart.callCount).to.equal(1);
+        expect(helper.slider.callOnChange.callCount).to.equal(1);
       });
 
       it('should handle click on ticks when showTicks is an integer and move minH', function() {
@@ -403,10 +403,9 @@
 
         expect(helper.scope.slider.value).to.equal(expectedValue);
         expect(helper.slider.tracking).to.equal('lowValue');
-        helper.slider.positionTrackingHandle.called.should.be.true;
-        helper.slider.callOnStart.called.should.be.true;
-        helper.slider.callOnChange.called.should.be.true;
+        expect(helper.slider.positionTrackingHandle.callCount).to.equal(1);
+        expect(helper.slider.callOnStart.callCount).to.equal(1);
+        expect(helper.slider.callOnChange.callCount).to.equal(1);
       });
   });
 }());
-

--- a/tests/specs/mouse-controls/single-slider-vertical-test.js
+++ b/tests/specs/mouse-controls/single-slider-vertical-test.js
@@ -81,8 +81,8 @@
 
       helper.fireMousemove(position, true);
       expect(helper.scope.slider.value).to.equal(expectedValue);
-      helper.slider.positionTrackingHandle.called.should.be.true;
-      helper.slider.callOnChange.called.should.be.true;
+      expect(helper.slider.positionTrackingHandle.callCount).to.equal(1);
+      expect(helper.slider.callOnChange.callCount).to.equal(1);
     });
 
     it('should handle click and drag on minH correctly when mouse is before the slider and previous value was different than 0', function() {
@@ -145,9 +145,9 @@
 
       expect(helper.scope.slider.value).to.equal(expectedValue);
       expect(helper.slider.tracking).to.equal('lowValue');
-      helper.slider.positionTrackingHandle.called.should.be.true;
-      helper.slider.callOnStart.called.should.be.true;
-      helper.slider.callOnChange.called.should.be.true;
+      expect(helper.slider.positionTrackingHandle.callCount).to.equal(1);
+      expect(helper.slider.callOnStart.callCount).to.equal(1);
+      expect(helper.slider.callOnChange.callCount).to.equal(1);
     });
 
     it('should handle click on selbar and move minH', function() {
@@ -162,9 +162,9 @@
 
       expect(helper.scope.slider.value).to.equal(expectedValue);
       expect(helper.slider.tracking).to.equal('lowValue');
-      helper.slider.positionTrackingHandle.called.should.be.true;
-      helper.slider.callOnStart.called.should.be.true;
-      helper.slider.callOnChange.called.should.be.true;
+      expect(helper.slider.positionTrackingHandle.callCount).to.equal(1);
+      expect(helper.slider.callOnStart.callCount).to.equal(1);
+      expect(helper.slider.callOnChange.callCount).to.equal(1);
     });
 
     it('should handle click on ticks and move minH', function() {
@@ -182,9 +182,9 @@
 
       expect(helper.scope.slider.value).to.equal(expectedValue);
       expect(helper.slider.tracking).to.equal('lowValue');
-      helper.slider.positionTrackingHandle.called.should.be.true;
-      helper.slider.callOnStart.called.should.be.true;
-      helper.slider.callOnChange.called.should.be.true;
+      expect(helper.slider.positionTrackingHandle.callCount).to.equal(1);
+      expect(helper.slider.callOnStart.callCount).to.equal(1);
+      expect(helper.slider.callOnChange.callCount).to.equal(1);
     });
 
     it('should handle click on ticks when showTicks is an integer and move minH', function() {
@@ -202,9 +202,9 @@
 
       expect(helper.scope.slider.value).to.equal(expectedValue);
       expect(helper.slider.tracking).to.equal('lowValue');
-      helper.slider.positionTrackingHandle.called.should.be.true;
-      helper.slider.callOnStart.called.should.be.true;
-      helper.slider.callOnChange.called.should.be.true;
+      expect(helper.slider.positionTrackingHandle.callCount).to.equal(1);
+      expect(helper.slider.callOnStart.callCount).to.equal(1);
+      expect(helper.slider.callOnChange.callCount).to.equal(1);
     });
   });
 
@@ -289,8 +289,8 @@
 
       helper.fireMousemove(position, true);
       expect(helper.scope.slider.value).to.equal(expectedValue);
-      helper.slider.positionTrackingHandle.called.should.be.true;
-      helper.slider.callOnChange.called.should.be.true;
+      expect(helper.slider.positionTrackingHandle.callCount).to.equal(1);
+      expect(helper.slider.callOnChange.callCount).to.equal(1);
     });
 
     it('should handle click and drag on minH correctly when mouse is before the slider and previous value was different than 0', function() {
@@ -353,9 +353,9 @@
 
       expect(helper.scope.slider.value).to.equal(expectedValue);
       expect(helper.slider.tracking).to.equal('lowValue');
-      helper.slider.positionTrackingHandle.called.should.be.true;
-      helper.slider.callOnStart.called.should.be.true;
-      helper.slider.callOnChange.called.should.be.true;
+      expect(helper.slider.positionTrackingHandle.callCount).to.equal(1);
+      expect(helper.slider.callOnStart.callCount).to.equal(1);
+      expect(helper.slider.callOnChange.callCount).to.equal(1);
     });
 
     it('should handle click on selbar and move minH', function() {
@@ -370,9 +370,9 @@
 
       expect(helper.scope.slider.value).to.equal(expectedValue);
       expect(helper.slider.tracking).to.equal('lowValue');
-      helper.slider.positionTrackingHandle.called.should.be.true;
-      helper.slider.callOnStart.called.should.be.true;
-      helper.slider.callOnChange.called.should.be.true;
+      expect(helper.slider.positionTrackingHandle.callCount).to.equal(1);
+      expect(helper.slider.callOnStart.callCount).to.equal(1);
+      expect(helper.slider.callOnChange.callCount).to.equal(1);
     });
 
     it('should handle click on ticks and move minH', function() {
@@ -390,9 +390,9 @@
 
       expect(helper.scope.slider.value).to.equal(expectedValue);
       expect(helper.slider.tracking).to.equal('lowValue');
-      helper.slider.positionTrackingHandle.called.should.be.true;
-      helper.slider.callOnStart.called.should.be.true;
-      helper.slider.callOnChange.called.should.be.true;
+      expect(helper.slider.positionTrackingHandle.callCount).to.equal(1);
+      expect(helper.slider.callOnStart.callCount).to.equal(1);
+      expect(helper.slider.callOnChange.callCount).to.equal(1);
     });
 
     it('should handle click on ticks when showTicks is an integer and move minH', function() {
@@ -410,11 +410,10 @@
 
       expect(helper.scope.slider.value).to.equal(expectedValue);
       expect(helper.slider.tracking).to.equal('lowValue');
-      helper.slider.positionTrackingHandle.called.should.be.true;
-      helper.slider.callOnStart.called.should.be.true;
-      helper.slider.callOnChange.called.should.be.true;
+      expect(helper.slider.positionTrackingHandle.callCount).to.equal(1);
+      expect(helper.slider.callOnStart.callCount).to.equal(1);
+      expect(helper.slider.callOnChange.callCount).to.equal(1);
     });
   });
 
 }());
-


### PR DESCRIPTION
…ion runs for tick values

Ensure translate function behaves the same for keyboard commands and drag events as mouse clicks by ensuring the model is applied before updateHandles is called. Currently when using mouse clicks to change the model of the slider, the translate function is called after the model is updated. My change ensures this same state when you drag a handle or use keyboard shortcuts. I've parameterized `applyModel` so that we only call the onchange event once if a change to the model has happened. @ValentinH, if there is a preferred approach to this other than I what I did, please advise and I'll update my PR.

I've made a second commit with the changes from running a build so the following fiddle will work. I can destroy once you've seen it working before anything gets merged. Updated [JSFiddle](http://jsfiddle.net/Lomg3b5z/2/) from issue to show now working example.

#498


