### PR TITLE
Update the labels on separation

### DIFF
--- a/src/rzslider.js
+++ b/src/rzslider.js
@@ -1358,6 +1358,8 @@
           this.showEl(this.cmbLab);
         } else {
           this.cmbLabelShown = false;
+          this.updateHighHandle(this.valueToPosition(this.highValue));
+          this.updateLowHandle(this.valueToPosition(this.lowValue));
           this.showEl(this.maxLab);
           this.showEl(this.minLab);
           this.hideEl(this.cmbLab);


### PR DESCRIPTION
When mergeRangeLabelsIfSame is set to true, two labels are combined once their values got close.
They got separated again if the values got away enough, but the text of a label stays the same with old one which is shown when it was combined.

Following gif shows the problem described above. 
![timeslot](https://cloud.githubusercontent.com/assets/9550/23016938/af7600d6-f47b-11e6-97b9-da231018f0f2.gif)

This patch solves the problem by updating the labels on separating combined labels.

