### PR TITLE
changed top: initial to top: auto for ie support

### DIFF
--- a/src/rzslider.less
+++ b/src/rzslider.less
@@ -141,7 +141,7 @@
 
   .rz-ticks-values-under {
     .rz-tick-value {
-      top: initial;
+      top: auto;
       bottom: @ticksValuePosition - 2;
     }
   }


### PR DESCRIPTION
Changed `top: intial` to `top: auto` . Works fine in IE11, chrome and mozilla.