### PR TITLE
fix slider jumps to first value if value is not in stepsArray

### DIFF
--- a/src/rzslider.js
+++ b/src/rzslider.js
@@ -450,7 +450,9 @@
           var index = 0
           for (var i = 0; i < this.options.stepsArray.length; i++) {
             var step = this.options.stepsArray[i]
-            if (step === modelValue) {
+            var lastStep = i > 0 ? this.options.stepsArray[i - 1] : 0;
+
+            if (step === modelValue || (modelValue > lastStep && modelValue < step)) {
               index = i
               break
             } else if (angular.isDate(step)) {


### PR DESCRIPTION
As I used the slider with a stepsArray and an input to change the value, I found that if a value is entered in the input that's not in the stepsArray the slider jumps to its minimum value.

I changed it so that it jumps to the next higher value instead.