### PR TITLE
Add 'slideChanged' event

### DIFF
--- a/dist/rzslider.js
+++ b/dist/rzslider.js
@@ -2674,6 +2674,7 @@
               )
             })
           }
+          this.scope.$emit('slideChanged')
         },
 
         /**


### PR DESCRIPTION
By adding a 'slideChanged' event to the callOnChange function, you're giving the user scope a much easier way to detect slider updates than having to listen to the local variable manually. I personally found this useful in my project, but I would rather not modify the source code on your project.